### PR TITLE
use rapier physics debug.

### DIFF
--- a/src/playState.ts
+++ b/src/playState.ts
@@ -47,7 +47,7 @@ export class PlayState implements IGameState {
   public voxelWorld: VoxelWorld; // New property for voxel world
   
   // Physics debug visualization properties
-  private physicsDebugRenderer: THREE.Mesh | null = null;
+  private physicsDebugRenderer: THREE.LineSegments | null = null;
 
   constructor(gameStateManager: GameStateManager) {
     // Create scene
@@ -1509,9 +1509,6 @@ export class PlayState implements IGameState {
   }
 
   private toggleDebugPhysics(isDebugMode: boolean): void {
-    // Set debug mode in voxel world
-    this.voxelWorld.setDebugPhysics(isDebugMode);
-
     // Clean up existing physics debug renderer if it exists
     if (this.physicsDebugRenderer) {
       this.scene.remove(this.physicsDebugRenderer);

--- a/src/playState.ts
+++ b/src/playState.ts
@@ -1511,6 +1511,12 @@ export class PlayState implements IGameState {
   private toggleDebugPhysics(isDebugMode: boolean): void {
     // Clean up existing physics debug renderer if it exists
     if (this.physicsDebugRenderer) {
+      if (this.physicsDebugRenderer.geometry) {
+        this.physicsDebugRenderer.geometry.dispose();
+      }
+      // if (this.physicsDebugRenderer.material) {
+        // this.physicsDebugRenderer.material.dispose();
+      // }
       this.scene.remove(this.physicsDebugRenderer);
       this.physicsDebugRenderer = null;
     }

--- a/src/playState.ts
+++ b/src/playState.ts
@@ -45,6 +45,9 @@ export class PlayState implements IGameState {
   private previousEnemyCount: number = 0;
 
   public voxelWorld: VoxelWorld; // New property for voxel world
+  
+  // Physics debug visualization properties
+  private physicsDebugRenderer: THREE.Mesh | null = null;
 
   constructor(gameStateManager: GameStateManager) {
     // Create scene
@@ -323,6 +326,40 @@ export class PlayState implements IGameState {
     this.handleInput(this.input!);
 
     this.physicsWorld.update(deltaTime);
+
+    // Update physics debug rendering if enabled
+    if (this.physicsDebugRenderer) {
+      // Get fresh debug rendering data
+      const buffers = this.physicsWorld.world.debugRender();
+      
+      // Update the geometry with new vertex data
+      const positions = this.physicsDebugRenderer.geometry.getAttribute('position');
+      const colors = this.physicsDebugRenderer.geometry.getAttribute('color');
+      
+      // Make sure buffer sizes match
+      if (positions.array.length === buffers.vertices.length && 
+          colors.array.length === buffers.colors.length) {
+        
+        // Update position and color data
+        positions.array.set(buffers.vertices);
+        positions.needsUpdate = true;
+        
+        colors.array.set(buffers.colors);
+        colors.needsUpdate = true;
+      } else {
+        // Buffer sizes changed, create new geometry
+        const vertices = new Float32Array(buffers.vertices);
+        const newColors = new Float32Array(buffers.colors);
+        
+        const geometry = new THREE.BufferGeometry();
+        geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3));
+        geometry.setAttribute('color', new THREE.BufferAttribute(newColors, 4));
+        
+        // Replace the old geometry
+        this.physicsDebugRenderer.geometry.dispose();
+        this.physicsDebugRenderer.geometry = geometry;
+      }
+    }
 
     // Update player and enemies
     this.player.update(deltaTime);
@@ -1474,6 +1511,38 @@ export class PlayState implements IGameState {
   private toggleDebugPhysics(isDebugMode: boolean): void {
     // Set debug mode in voxel world
     this.voxelWorld.setDebugPhysics(isDebugMode);
+
+    // Clean up existing physics debug renderer if it exists
+    if (this.physicsDebugRenderer) {
+      this.scene.remove(this.physicsDebugRenderer);
+      this.physicsDebugRenderer = null;
+    }
+
+    // If debug mode is enabled, create the debug renderer
+    if (isDebugMode) {
+      // Use RAPIER.World.debugRender() to get physics visualization
+      const buffers = this.physicsWorld.world.debugRender();
+      
+      // Create debug rendering geometry
+      const vertices = new Float32Array(buffers.vertices);
+      const colors = new Float32Array(buffers.colors);
+      
+      // Create buffer geometry and set attributes
+      const geometry = new THREE.BufferGeometry();
+      geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3));
+      geometry.setAttribute('color', new THREE.BufferAttribute(colors, 4));
+      
+      // Create material with vertex colors
+      const material = new THREE.LineBasicMaterial({
+        vertexColors: true,
+        transparent: true,
+        opacity: 0.7
+      });
+      
+      // Create the debug renderer mesh and add it to the scene
+      this.physicsDebugRenderer = new THREE.LineSegments(geometry, material);
+      this.scene.add(this.physicsDebugRenderer);
+    }
 
     // Create a notification about debug physics mode
     const debugNotification = document.createElement('div');

--- a/src/voxelWorld.ts
+++ b/src/voxelWorld.ts
@@ -36,8 +36,6 @@ export class VoxelWorld {
   private config: GameConfig;
   private materialMeshes: THREE.MeshStandardMaterial[] = [];
   private geometry: THREE.BoxGeometry;
-  private debugPhysics: boolean = false;
-  private debugMeshes: THREE.Mesh[] = [];
 
   constructor(playState : PlayState, scene: THREE.Scene, physicsWorld: PhysicsWorld, config: GameConfig) {
     this.state = playState;
@@ -62,30 +60,6 @@ export class VoxelWorld {
         });
         this.materialMeshes[materialType as number] = meshMaterial;
       });
-  }
-
-  // Enable or disable physics debug visualization
-  setDebugPhysics(enabled: boolean): void {
-    this.debugPhysics = enabled;
-
-    // Clear existing debug meshes if turning off
-    if (!enabled) {
-      this.clearDebugMeshes();
-      return;
-    }
-
-    // Re-render all chunks to show debug visualization
-    for (const chunk of this.chunks.values()) {
-      chunk.dirty = true;
-    }
-  }
-
-  // Clear all debug visualization meshes
-  private clearDebugMeshes(): void {
-    for (const mesh of this.debugMeshes) {
-      this.scene.remove(mesh);
-    }
-    this.debugMeshes = [];
   }
 
   // Get or create a chunk at the specified position
@@ -282,22 +256,6 @@ export class VoxelWorld {
 
           const keyStr = `${localPos.x},${localPos.y},${localPos.z}`;
           chunk.physicsObjects.set(keyStr, gameObj);
-
-          // Add debug visualization if debug mode is enabled
-          if (this.debugPhysics) {
-            const debugGeometry = new THREE.BoxGeometry(VOXEL_SIZE, VOXEL_SIZE, VOXEL_SIZE);
-            const debugMaterial = new THREE.MeshBasicMaterial({
-              color: 0xff0000,
-              wireframe: true,
-              transparent: true,
-              opacity: 0.7
-            });
-
-            const debugMesh = new THREE.Mesh(debugGeometry, debugMaterial);
-            debugMesh.position.copy(worldPos);
-            this.scene.add(debugMesh);
-            this.debugMeshes.push(debugMesh);
-          }
         }
       });
 
@@ -774,23 +732,6 @@ export class VoxelWorld {
     const mesh = new THREE.Mesh(geometry, meshMaterial);
     mesh.position.copy(worldPos);
 
-    // Create debug visualization if debug mode is enabled
-    let debugMesh: THREE.Mesh | null = null;
-    if (this.debugPhysics) {
-      const debugGeometry = new THREE.BoxGeometry(VOXEL_SIZE, VOXEL_SIZE, VOXEL_SIZE);
-      const debugMaterial = new THREE.MeshBasicMaterial({
-        color: 0xff0000,
-        wireframe: true,
-        transparent: true,
-        opacity: 0.7
-      });
-
-      debugMesh = new THREE.Mesh(debugGeometry, debugMaterial);
-      debugMesh.position.copy(worldPos);
-      this.scene.add(debugMesh);
-      this.debugMeshes.push(debugMesh);
-    }
-
     // Create the game object
     const gameObj: GameObject = {
       mesh,
@@ -804,22 +745,10 @@ export class VoxelWorld {
         const rotation = body.rotation();
         mesh.quaternion.set(rotation.x, rotation.y, rotation.z, rotation.w);
 
-        // Update debug mesh if it exists
-        if (debugMesh) {
-          debugMesh.position.copy(mesh.position);
-          debugMesh.quaternion.copy(mesh.quaternion);
-        }
 
         // Remove if fallen too far (cleanup)
         if (position.y < -20) {
           this.state.removeDebris(gameObj);
-          if (debugMesh) {
-            this.scene.remove(debugMesh);
-            const index = this.debugMeshes.indexOf(debugMesh);
-            if (index !== -1) {
-              this.debugMeshes.splice(index, 1);
-            }
-          }
           return false; // Signal that this object should be removed
         }
 


### PR DESCRIPTION
This pull request removes voxel-specific physics debug visualization from the VoxelWorld and implements global debug rendering using Rapier's physics debug data in PlayState. Key changes include:

- Removal of debug-related properties and methods from VoxelWorld.
- Introduction of a new physicsDebugRenderer property in PlayState.
- Updating the game loop and toggle method in PlayState to use Rapier’s debugRender buffers for real-time physics visualization.